### PR TITLE
Multiple updates

### DIFF
--- a/GetBaseCountsMultiSample.cpp
+++ b/GetBaseCountsMultiSample.cpp
@@ -62,8 +62,8 @@ bool input_variant_is_maf = false;
 bool input_variant_is_vcf = false;
 bool output_maf = false;
 const size_t BIN_SIZE = 16*1024;
-const float FRAGMENT_REF_WEIGHT = 0.5;
-const float FRAGMENT_ALT_WEIGHT = 0.5;
+const float FRAGMENT_REF_WEIGHT = 0;
+const float FRAGMENT_ALT_WEIGHT = 0;
 enum Count_Type {DP, RD, AD, DPP, RDP, ADP, DPF, RDF, ADF, NUM_COUNT_TYPE}; // NUM_COUNT_TYPE will have the size of Count_Type
 bool has_chr;
 int max_warning_per_type = 3;
@@ -835,7 +835,7 @@ void loadVariantFileMAF(vector<string>& input_file_names, vector<VariantEntry *>
             int pos = atoi(variant_items[header_index_hash["Start_Position"]].c_str()) - 1; //convert to 0-indexed, to be consistent with bam entry
             int end_pos = atoi(variant_items[header_index_hash["End_Position"]].c_str()) - 1;
             string ref = variant_items[header_index_hash["Reference_Allele"]];
-            string alt = variant_items[header_index_hash["Tumor_Seq_Allele1"]];
+            string alt = variant_items[header_index_hash["Tumor_Seq_Allele2"]];
             int maf_pos = pos;
             int maf_end_pos = end_pos;
             string maf_ref = ref;
@@ -1168,7 +1168,7 @@ void printCountsMaf(vector<VariantEntry *>& variant_vec) // print counts for tcg
             float vf_count = 0.0;
             if(counts[DP] > 0)
                 vf_count = counts[AD] / counts[DP];
-            output_fs << variant_vec[i]->gene << "\t" << "" << "\t" << maf_output_center << "\t" << maf_output_genome_build << "\t" << variant_vec[i]->chrom << "\t" << (variant_vec[i]->maf_pos + 1) << "\t" << (variant_vec[i]->maf_end_pos + 1) << "\t" << "+" << "\t" << variant_vec[i]->effect << "\t" << variant_type << "\t" << variant_vec[i]->maf_ref << "\t" << variant_vec[i]->maf_alt << "\t" << "" << "\t" << "" << "\t" << "" << "\t" << output_sample_order[j] << "\t" << "Normal" << "\t" << "" << "\t" << "" << "\t" << "" << "\t" << "" << "\t" << "" << "\t" << "" << "\t" << "" << "\t" << "" << "\t" << "UNPAIRED" << "\t" << "" << "\t" << "" << "\t" << "" << "\t" << "" << "\t" << "" << "\t" << "" << "\t" << counts[RD] << "\t" << counts[AD] << "\t" << "" << "\t" << "" << "\t" << variant_vec[i]->caller << "\t" << counts[DP] << "\t" << vf_count;
+            output_fs << variant_vec[i]->gene << "\t" << "" << "\t" << maf_output_center << "\t" << maf_output_genome_build << "\t" << variant_vec[i]->chrom << "\t" << (variant_vec[i]->maf_pos + 1) << "\t" << (variant_vec[i]->maf_end_pos + 1) << "\t" << "+" << "\t" << variant_vec[i]->effect << "\t" << variant_type << "\t" << variant_vec[i]->maf_ref << "\t" << variant_vec[i]->maf_ref << "\t" << variant_vec[i]->maf_alt << "\t" << "" << "\t" << "" << "\t" << output_sample_order[j] << "\t" << "Normal" << "\t" << "" << "\t" << "" << "\t" << "" << "\t" << "" << "\t" << "" << "\t" << "" << "\t" << "" << "\t" << "" << "\t" << "UNPAIRED" << "\t" << "" << "\t" << "" << "\t" << "" << "\t" << "" << "\t" << "" << "\t" << "" << "\t" << counts[RD] << "\t" << counts[AD] << "\t" << "" << "\t" << "" << "\t" << variant_vec[i]->caller << "\t" << counts[DP] << "\t" << vf_count;
             if(output_positive_count)
                 output_fs << "\t" << counts[DPP]  << "\t" << counts[RDP] << "\t" << counts[ADP];
             if(output_negative_count)

--- a/GetBaseCountsMultiSample.cpp
+++ b/GetBaseCountsMultiSample.cpp
@@ -915,13 +915,14 @@ void loadVariantFileMAF(vector<string>& input_file_names, vector<VariantEntry *>
             int pos = atoi(variant_items[header_index_hash["Start_Position"]].c_str()) - 1; //convert to 0-indexed, to be consistent with bam entry
             int end_pos = atoi(variant_items[header_index_hash["End_Position"]].c_str()) - 1;
             string ref = variant_items[header_index_hash["Reference_Allele"]];
-            string alt = variant_items[header_index_hash["Tumor_Seq_Allele2"]];
+            string alt = variant_items[header_index_hash["Tumor_Seq_Allele1"]];
             int maf_pos = pos;
             int maf_end_pos = end_pos;
             string maf_ref = ref;
             string maf_alt = alt;
             if(alt.empty() || alt == ref)
                 alt = variant_items[header_index_hash["Tumor_Seq_Allele2"]];
+	        maf_alt = alt;
             if(alt.empty())
             {
                 cerr << "Could not find alt allele for variant: " << chrom << "\t" << pos << endl;

--- a/GetBaseCountsMultiSample.cpp
+++ b/GetBaseCountsMultiSample.cpp
@@ -62,8 +62,8 @@ bool input_variant_is_maf = false;
 bool input_variant_is_vcf = false;
 bool output_maf = false;
 const size_t BIN_SIZE = 16*1024;
-const float FRAGMENT_REF_WEIGHT = 0;
-const float FRAGMENT_ALT_WEIGHT = 0;
+float FRAGMENT_REF_WEIGHT = 0;
+float FRAGMENT_ALT_WEIGHT = 0;
 enum Count_Type {DP, RD, AD, DPP, RDP, ADP, DPF, RDF, ADF, NUM_COUNT_TYPE}; // NUM_COUNT_TYPE will have the size of Count_Type
 bool has_chr;
 int max_warning_per_type = 3;
@@ -226,6 +226,7 @@ void printUsage(string msg = "")
     cout << "\t--positive_count        [0, 1]                          Whether to output positive strand read counts DPP/RDP/ADP. 0=off, 1=on. Default 1" << endl;
     cout << "\t--negative_count        [0, 1]                          Whether to output negative strand read counts DPN/RDN/ADN. 0=off, 1=on. Default 0" << endl;
     cout << "\t--fragment_count        [0, 1]                          Whether to output fragment read counts DPF/RDF/ADF. 0=off, 1=on. Default 0" << endl;
+    cout << "\t--fragment_fractional_weight                            Whether to add a fractional depth (0.5) when there is disaggrement between strands on an ALT allele. Default 0" << endl;
     cout << "\t--suppress_warning      <int>                           Only print a limit number of warnings for each type. Default " << max_warning_per_type << endl;
     cout << "\t--help                                                  Print command line usage" << endl;
     cout << endl;
@@ -260,6 +261,7 @@ static struct option long_options[] =
     {"positive_count",          required_argument,      0,     'P'},
     {"negative_count",          required_argument,      0,     'N'},
     {"fragment_count",          required_argument,      0,     'F'},
+    {"fragment_fractional_weight",    no_argument,      0,     'W'},
     {"suppress_warning",        required_argument,      0,     'w'},
     {"max_block_size",          required_argument,      0,     'M'},
     {"max_block_dist",          required_argument,      0,     'm'},
@@ -277,7 +279,7 @@ void parseOption(int argc, const char* argv[])
     int option_index = 0;
     do
     {
-        next_option = getopt_long(argc, const_cast<char**>(argv), "f:b:B:v:V:o:t:OQ:q:d:p:l:i:n:P:N:F:w:M:m:h", long_options, &option_index);
+        next_option = getopt_long(argc, const_cast<char**>(argv), "f:b:B:v:V:o:t:OQ:q:d:p:l:i:n:P:N:F:W:w:M:m:h", long_options, &option_index);
         switch(next_option)
         {
             case 'f':
@@ -368,6 +370,9 @@ void parseOption(int argc, const char* argv[])
                     output_fragment_count = atoi(optarg);
                 else
                     printUsage("[ERROR] Invalid value for --fragment_count");
+                break;
+            case 'W':
+                FRAGMENT_REF_WEIGHT = FRAGMENT_ALT_WEIGHT = 0.5;
                 break;
             case 'w':
                 if(isNumber(optarg))


### PR DESCRIPTION
- Enabled providing multiple bam files as a fof instead of multiple `--bam` arguments
- Corrected parsing of Tumor_Seq_Allele1/Tumor_Seq_Allele2 in input maf. And reporting of the ALT allele in the output maf
- FRAGMENT_REF_WEIGHT and FRAGMENT_ALT_WEIGHT defaulted to 0. Added an optional argument --fragment_fractional_weight that will add a weight of 0.5 to fragment depth when there is discrepancy between read strands for a REF/ALT allele